### PR TITLE
Fix repguild

### DIFF
--- a/src/Components/Fixtures/index.ts
+++ b/src/Components/Fixtures/index.ts
@@ -42,5 +42,4 @@ export const guildConfigMock: GuildConfigProps = {
   votingPowerForProposalExecution: BigNumber.from(3000000000000000),
   tokenVault: '0xEE945a0fa35b2B9046D244e465861221c766069F',
   lockTime: BigNumber.from(300),
-  totalLocked: BigNumber.from(1000000000000000),
 };

--- a/src/Modules/Guilds/Wrappers/SidebarInfoCardWrapper.tsx
+++ b/src/Modules/Guilds/Wrappers/SidebarInfoCardWrapper.tsx
@@ -1,12 +1,16 @@
 import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 import { useGuildConfig } from 'hooks/Guilds/ether-swr/guild/useGuildConfig';
 import useVotingPowerPercent from 'hooks/Guilds/guild/useVotingPowerPercent';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
 import { SidebarInfoCard } from 'Components/SidebarInfoCard';
+
 const SidebarInfoCardWrapper = () => {
   const { guildId } = useTypedParams();
   const {
-    data: { proposalTime, votingPowerForProposalExecution, totalLocked },
+    data: { proposalTime, votingPowerForProposalExecution },
   } = useGuildConfig(guildId);
+
+  const { data: totalLocked } = useTotalLocked(guildId);
 
   const quorum = useVotingPowerPercent(
     votingPowerForProposalExecution,

--- a/src/hooks/Guilds/ether-swr/guild/useGuildConfig.ts
+++ b/src/hooks/Guilds/ether-swr/guild/useGuildConfig.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { SWRResponse } from 'swr';
 import ERC20GuildContract from 'contracts/ERC20Guild.json';
 import useEtherSWR from '../useEtherSWR';
-import useTotalLocked from './useTotalLocked';
 import useGuildToken from './useGuildToken';
 
 export type GuildConfigProps = {
@@ -17,7 +16,6 @@ export type GuildConfigProps = {
   votingPowerForProposalExecution: BigNumber;
   tokenVault: string;
   lockTime: BigNumber;
-  totalLocked: BigNumber;
 };
 
 export const useGuildConfig = (
@@ -43,7 +41,6 @@ export const useGuildConfig = (
     }
   );
   const { data: token } = useGuildToken(guildAddress);
-  const { data: totalLocked } = useTotalLocked(guildAddress);
 
   // TODO: Move this into a SWR middleware
   const transformedData = useMemo(() => {
@@ -82,8 +79,6 @@ export const useGuildConfig = (
     error,
     isValidating,
     mutate,
-    data: transformedData
-      ? { ...transformedData, totalLocked, token }
-      : undefined,
+    data: transformedData ? { ...transformedData, token } : undefined,
   };
 };

--- a/src/hooks/Guilds/ether-swr/guild/useSnapshotId.ts
+++ b/src/hooks/Guilds/ether-swr/guild/useSnapshotId.ts
@@ -12,9 +12,10 @@ interface UseSnapshotIdProps {
 type UseSnapshotIdHook = (args: UseSnapshotIdProps) => SWRResponse<BigNumber>;
 
 const useSnapshotId: UseSnapshotIdHook = ({ contractAddress, proposalId }) => {
-  const { isSnapshotGuild } = useGuildImplementationTypeConfig(contractAddress);
+  const { isSnapshotGuild, isSnapshotRepGuild } =
+    useGuildImplementationTypeConfig(contractAddress);
   return useEtherSWR(
-    isSnapshotGuild && proposalId && contractAddress
+    (isSnapshotGuild || isSnapshotRepGuild) && proposalId && contractAddress
       ? [contractAddress, 'getProposalSnapshotId', proposalId]
       : [],
     {

--- a/src/hooks/Guilds/ether-swr/guild/useVotingResults.ts
+++ b/src/hooks/Guilds/ether-swr/guild/useVotingResults.ts
@@ -3,6 +3,8 @@ import { useGuildConfig } from './useGuildConfig';
 import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 import { BigNumber } from 'ethers';
 import { useProposal } from 'hooks/Guilds/ether-swr/guild/useProposal';
+import useSnapshotId from 'hooks/Guilds/ether-swr/guild/useSnapshotId';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
 import { useMemo } from 'react';
 
 export interface VoteData {
@@ -23,8 +25,16 @@ export const useVotingResults = (
     optionalGuildId || guildId,
     optionalProposalId || proposalId
   );
+
   const { data } = useGuildConfig(optionalGuildId || guildId);
   const { data: tokenInfo } = useERC20Info(data?.token);
+
+  const { data: snapshotId } = useSnapshotId({
+    contractAddress: guildId,
+    proposalId: proposal?.id,
+  });
+
+  const { data: totalLocked } = useTotalLocked(guildId, snapshotId?.toString());
 
   const voteData = useMemo(() => {
     if (!proposal || !data || !tokenInfo) return undefined;
@@ -38,10 +48,10 @@ export const useVotingResults = (
     return {
       options,
       quorum: data?.votingPowerForProposalExecution,
-      totalLocked: data?.totalLocked,
+      totalLocked,
       token: tokenInfo,
     };
-  }, [data, proposal, tokenInfo]);
+  }, [data, proposal, tokenInfo, totalLocked]);
 
   return voteData;
 };

--- a/src/hooks/Guilds/useVoteSummary.ts
+++ b/src/hooks/Guilds/useVoteSummary.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useProposal } from 'hooks/Guilds/ether-swr/guild/useProposal';
-import { useGuildConfig } from './ether-swr/guild/useGuildConfig';
+import useSnapshotId from 'hooks/Guilds/ether-swr/guild/useSnapshotId';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
+
 import { getBigNumberPercentage } from 'utils/bnPercentage';
 
 // Gets vote summary as array of percentages
@@ -8,13 +10,20 @@ export default function useVoteSummary(
   guildId: string,
   proposalId: string
 ): number[] {
-  const { data: { totalVotes = null } = {} } = useProposal(guildId, proposalId);
-  const { data: { totalLocked = null } = {} } = useGuildConfig(guildId);
+  const { data: { totalVotes } = {} } = useProposal(guildId, proposalId);
+
+  const { data: snapshotId } = useSnapshotId({
+    contractAddress: guildId,
+    proposalId,
+  });
+
+  const { data: totalLocked } = useTotalLocked(guildId, snapshotId?.toString());
+
   const votes = useMemo(() => {
     if (totalVotes && totalLocked) {
       const newVotes = [];
-
-      for (var i = 0; i < totalVotes?.length - 1; i++) {
+      // Skipping the first and showing results from 2nd item (idx 1) onwards. Same case as useVotingResults. TODO: investigate why?
+      for (var i = 1; i <= totalVotes?.length - 1; i++) {
         if (totalVotes[i]?.gt(0)) {
           newVotes.push(getBigNumberPercentage(totalVotes[i], totalLocked, 2));
         } else {

--- a/src/old-components/Guilds/ProposalPage/ProposalInfoCard/index.tsx
+++ b/src/old-components/Guilds/ProposalPage/ProposalInfoCard/index.tsx
@@ -8,6 +8,8 @@ import InfoItem from './InfoItem';
 import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 import { useGuildConfig } from 'hooks/Guilds/ether-swr/guild/useGuildConfig';
 import useVotingPowerPercent from 'hooks/Guilds/guild/useVotingPowerPercent';
+import useSnapshotId from 'hooks/Guilds/ether-swr/guild/useSnapshotId';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
 import moment, { duration } from 'moment';
 import { Loading } from 'Components/Primitives/Loading';
 import React, { useMemo, useState } from 'react';
@@ -65,9 +67,17 @@ const ProposalInfoCard: React.FC = () => {
   const { data: proposal, error } = useProposal(guildId, proposalId);
 
   const { data: guildConfig } = useGuildConfig(guildId);
+
+  const { data: snapshotId } = useSnapshotId({
+    contractAddress: guildId,
+    proposalId,
+  });
+
+  const { data: totalLocked } = useTotalLocked(guildId, snapshotId?.toString());
+
   const quorum = useVotingPowerPercent(
     guildConfig?.votingPowerForProposalExecution,
-    guildConfig?.totalLocked
+    totalLocked
   );
 
   const endDetail = useMemo(() => {

--- a/src/old-components/Guilds/Sidebar/MemberActions.tsx
+++ b/src/old-components/Guilds/Sidebar/MemberActions.tsx
@@ -8,6 +8,7 @@ import { useVoterLockTimestamp } from '../../../hooks/Guilds/ether-swr/guild/use
 import { useVotingPowerOf } from '../../../hooks/Guilds/ether-swr/guild/useVotingPowerOf';
 import useGuildImplementationType from '../../../hooks/Guilds/guild/useGuildImplementationType';
 import useVotingPowerPercent from '../../../hooks/Guilds/guild/useVotingPowerPercent';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
 import { shortenAddress } from '../../../utils';
 import { MAINNET_ID } from '../../../utils/constants';
 import Avatar from '../Avatar';
@@ -101,9 +102,11 @@ export const MemberActions = () => {
     if (showStakeModal) setShowMenu(false);
   }, [showStakeModal]);
 
+  const { data: totalLocked } = useTotalLocked(guildAddress);
+
   const votingPowerPercent = useVotingPowerPercent(
     userVotingPower,
-    guildConfig?.totalLocked
+    totalLocked
   );
 
   const roundedBalance = useBigNumberToNumber(

--- a/src/old-components/Guilds/StakeTokensModal/StakeTokens.tsx
+++ b/src/old-components/Guilds/StakeTokensModal/StakeTokens.tsx
@@ -8,6 +8,7 @@ import { useGuildConfig } from '../../../hooks/Guilds/ether-swr/guild/useGuildCo
 import { useVotingPowerOf } from '../../../hooks/Guilds/ether-swr/guild/useVotingPowerOf';
 import useGuildImplementationType from '../../../hooks/Guilds/guild/useGuildImplementationType';
 import useVotingPowerPercent from '../../../hooks/Guilds/guild/useVotingPowerPercent';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
 import { Button } from '../common/Button';
 import TokenAmountInput from '../common/Form/TokenAmountInput';
 import { Loading } from '../../../Components/Primitives/Loading';
@@ -125,6 +126,7 @@ export const StakeTokens = () => {
   const { guildId: guildAddress } = useTypedParams();
   const { data: guildConfig } = useGuildConfig(guildAddress);
   const { data: tokenInfo } = useERC20Info(guildConfig?.token);
+  const { data: totalLocked } = useTotalLocked(guildAddress);
 
   const { data: tokenBalance } = useERC20Balance(
     guildConfig?.token,
@@ -178,12 +180,12 @@ export const StakeTokens = () => {
 
   const votingPowerPercent = useVotingPowerPercent(
     userVotingPower,
-    guildConfig?.totalLocked,
+    totalLocked,
     3
   );
   const nextVotingPowerPercent = useVotingPowerPercent(
     stakeAmount?.add(userVotingPower),
-    stakeAmount?.add(guildConfig?.totalLocked),
+    stakeAmount?.add(totalLocked),
     3
   );
   const history = useHistory();

--- a/src/pages/Guilds/Proposal.tsx
+++ b/src/pages/Guilds/Proposal.tsx
@@ -10,6 +10,9 @@ import UnstyledLink from 'Components/Primitives/Links/UnstyledLink';
 import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 import { GuildAvailabilityContext } from 'contexts/Guilds/guildAvailability';
 import { useGuildProposalIds } from 'hooks/Guilds/ether-swr/guild/useGuildProposalIds';
+import useTotalLocked from 'hooks/Guilds/ether-swr/guild/useTotalLocked';
+import useSnapshotId from 'hooks/Guilds/ether-swr/guild/useSnapshotId';
+
 import useProposalCalls from 'hooks/Guilds/guild/useProposalCalls';
 import { ActionsBuilder } from 'old-components/Guilds/CreateProposalPage';
 import { Loading } from 'Components/Primitives/Loading';
@@ -97,9 +100,16 @@ const ProposalPage: React.FC = () => {
     proposalId
   );
 
+  const { data: snapshotId } = useSnapshotId({
+    contractAddress: guildId,
+    proposalId,
+  });
+
+  const { data: totalLocked } = useTotalLocked(guildId, snapshotId?.toString());
+
   const quorum = useVotingPowerPercent(
     guildConfig?.votingPowerForProposalExecution,
-    guildConfig?.totalLocked
+    totalLocked
   );
 
   const status = useProposalState(proposal);


### PR DESCRIPTION
# Description
TotalLocked was being pulled from guildconfig hook. That hook wasn't considering snapshot based implementations so totalLocked was returning null and voting info was empty. 

Solution: 
- remove totalLocked key from useGuildConfig hook. 
- Refactor all components that were using totalLocked key from guildConfig. 
- Implement useTotalLocked in those cases and also get the snapshotId at the proposal level where is possible. 
- In useVoteSummary hook I removed the 1st entry in proposal.totalVotes and not the last as it was, since votes weren't being shown. 



Closes https://github.com/DXgovernance/DAVI/issues/48

Before:
<img width="854" alt="Screen Shot 2022-06-07 at 12 37 42" src="https://user-images.githubusercontent.com/25844967/172422477-edf80dbc-309e-469e-9510-319a8b08b3ec.png">

After: 
<img width="855" alt="Screen Shot 2022-06-07 at 12 35 19" src="https://user-images.githubusercontent.com/25844967/172422544-6289c1c3-6796-4537-b517-ecbc06669453.png">
