### PR TITLE
Avoid redirect when skeleton (loading) proposalCard is displayed

### DIFF
--- a/src/Components/ProposalCard/ProposalCard.styled.ts
+++ b/src/Components/ProposalCard/ProposalCard.styled.ts
@@ -3,15 +3,19 @@ import { Box } from 'Components/Primitives/Layout';
 import { Heading } from 'old-components/Guilds/common/Typography';
 
 // TODO: base these components on a generic Card component
-export const CardWrapper = styled(Box)`
+export const CardWrapper = styled(Box)<{ disabled?: boolean }>`
   border: 1px solid ${({ theme }) => theme.colors.muted};
   border-radius: ${({ theme }) => theme.radii.curved};
   margin-bottom: 1rem;
   padding: 1rem;
   color: ${({ theme }) => theme.colors.proposalText.lightGrey};
+
   &:hover {
-    border-color: ${({ theme }) => theme.colors.border.hover};
-    color: ${({ theme }) => theme.colors.text};
+    ${({ theme, disabled }) =>
+      disabled
+        ? `cursor: default;`
+        : `border-color: ${theme.colors.border.hover};
+          color: ${theme.colors.text};`}
   }
 `;
 

--- a/src/Components/ProposalCard/ProposalCard.tsx
+++ b/src/Components/ProposalCard/ProposalCard.tsx
@@ -27,7 +27,7 @@ const ProposalCard: React.FC<ProposalCardProps> = ({
 }) => {
   return (
     <UnstyledLink to={href || '#'} data-testid="proposal-card">
-      <CardWrapper>
+      <CardWrapper disabled={!href}>
         <CardHeader>
           <IconDetailWrapper>
             <Avatar

--- a/src/Components/ProposalCard/__snapshots__/ProposalCard.test.tsx.snap
+++ b/src/Components/ProposalCard/__snapshots__/ProposalCard.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ProposalCard ProposalCard Renders properly with data 1`] = `
     href="/testUrl"
   >
     <div
-      class="sc-iqHYmW sc-flMpop fkFZia fhkIyA"
+      class="sc-iqHYmW sc-flMpop fkFZia cbiNNm"
     >
       <div
         class="sc-iqHYmW sc-eWVLlQ fkFZia fKXacY"
@@ -175,7 +175,8 @@ exports[`ProposalCard ProposalCard loading 1`] = `
     href="/"
   >
     <div
-      class="sc-iqHYmW sc-flMpop fkFZia fhkIyA"
+      class="sc-iqHYmW sc-flMpop fkFZia jtJLDV"
+      disabled=""
     >
       <div
         class="sc-iqHYmW sc-eWVLlQ fkFZia fKXacY"

--- a/src/Modules/Guilds/Wrappers/ProposalCardWrapper.tsx
+++ b/src/Modules/Guilds/Wrappers/ProposalCardWrapper.tsx
@@ -26,7 +26,9 @@ const ProposalCardWrapper: React.FC<ProposalCardWrapperProps> = ({
       proposal={{ ...proposal, id: proposalId }}
       ensAvatar={ensAvatar}
       votes={votes}
-      href={`/${chainName}/${guildId}/proposal/${proposalId}`}
+      href={
+        proposalId ? `/${chainName}/${guildId}/proposal/${proposalId}` : null
+      }
       statusProps={{
         timeDetail: proposal?.timeDetail,
         status,


### PR DESCRIPTION
# Description
On guild page we show a list of ProposalCardWrappers with no proposal id (just to show some loading proposals). 
If we clicked there we where redirecting to invalid url. 
The fix is to avoid that is no proposalId prop is passed, we shouldn't be able to click on proposal. 

Closes https://github.com/DXgovernance/DAVI/issues/54

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
