### PR TITLE
Set permissionRegistry address for setPermission action TO field

### DIFF
--- a/src/Components/ActionsBuilder/SupportedActions/index.tsx
+++ b/src/Components/ActionsBuilder/SupportedActions/index.tsx
@@ -140,7 +140,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       from: '',
       callType: SupportedAction.SET_PERMISSIONS,
       function: PermissionRegistryContract.getFunction('setETHPermission'),
-      to: '0xD899Be87df2076e0Be28486b60dA406Be6757AfC',
+      to: '',
       value: BigNumber.from(0),
       args: {
         to: '',

--- a/src/Components/ActionsModal/ActionsModal.test.tsx
+++ b/src/Components/ActionsModal/ActionsModal.test.tsx
@@ -14,6 +14,13 @@ jest.mock('hooks/Guilds/guild/useGuildImplementationType', () => ({
     isSnapshotRepGuild: false,
   }),
 }));
+jest.mock('hooks/Guilds/ether-swr/guild/useGuildConfig', () => ({
+  useGuildConfig: () => ({
+    data: {
+      permissionRegistry: '0x0000000000000000000000000000000000000000',
+    },
+  }),
+}));
 
 jest.mock('wagmi', () => ({
   useAccount: () => ({ isConnected: true }),

--- a/src/Components/ActionsModal/ActionsModal.tsx
+++ b/src/Components/ActionsModal/ActionsModal.tsx
@@ -28,6 +28,7 @@ import { EditorWrapper } from './ActionsModal.styled';
 import { ActionModalProps } from './types';
 import { TokenSpendApproval } from './components/ApproveSpendTokens/ApproveSpendTokens';
 import { useAccount } from 'wagmi';
+import { useGuildConfig } from 'hooks/Guilds/ether-swr/guild/useGuildConfig';
 
 const ActionModal: React.FC<ActionModalProps> = ({
   action,
@@ -38,6 +39,7 @@ const ActionModal: React.FC<ActionModalProps> = ({
   const { t } = useTranslation();
   const { guildId } = useTypedParams();
   const { address: walletAddress } = useAccount();
+  const { data: guildConfig } = useGuildConfig(guildId);
   // Supported Actions
   const [selectedAction, setSelectedAction] =
     React.useState<SupportedAction>(null);
@@ -197,6 +199,7 @@ const ActionModal: React.FC<ActionModalProps> = ({
         break;
       case SupportedAction.SET_PERMISSIONS:
         defaultDecodedAction.decodedCall.args.from = guildId;
+        defaultDecodedAction.decodedCall.to = guildConfig?.permissionRegistry;
         break;
     }
     setData(defaultDecodedAction.decodedCall);


### PR DESCRIPTION
# Description
Change hardcoded "to" field for decoded (setPermission) action to the actual guildRegistry address. 
