### PR TITLE
fix: Specify guild id for token picker

### DIFF
--- a/src/Components/ActionsBuilder/SupportedActions/ERC20Transfer/ERC20TransferEditor.tsx
+++ b/src/Components/ActionsBuilder/SupportedActions/ERC20Transfer/ERC20TransferEditor.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useNetwork } from 'wagmi';
 import validateERC20Transfer from './validateERC20Transfer';
 import { ErrorLabel } from 'Components/Primitives/Forms/ErrorLabel';
+import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 
 const Error = styled(ErrorLabel)`
   margin-top: 0.5rem;
@@ -71,6 +72,7 @@ const ERC20TransferEditor: React.FC<ActionEditorProps> = ({
 
   const [isTokenPickerOpen, setIsTokenPickerOpen] = useState(false);
 
+  const { guildId } = useTypedParams();
   const { chain } = useNetwork();
 
   // Get token details from the token address
@@ -204,7 +206,7 @@ const ERC20TransferEditor: React.FC<ActionEditorProps> = ({
 
                   <TokenPicker
                     {...field}
-                    walletAddress={parsedData.source || ''}
+                    walletAddress={guildId}
                     isOpen={isTokenPickerOpen}
                     onClose={() => setIsTokenPickerOpen(false)}
                     onSelect={tokenAddress => {

--- a/src/Components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.tsx
+++ b/src/Components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.tsx
@@ -30,6 +30,7 @@ import Input from 'old-components/Guilds/common/Form/Input';
 import Avatar from 'old-components/Guilds/Avatar';
 import { TokenPicker } from 'Components/TokenPicker';
 import { DecodedCall } from 'Components/ActionsBuilder/types';
+import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
 
 const Web3 = require('web3');
 const web3 = new Web3();
@@ -80,6 +81,7 @@ const Permissions: React.FC<ActionEditorProps> = ({
     },
   });
 
+  const { guildId } = useTypedParams();
   const { tokenAddress } = getValues();
 
   // Get token details from the token address
@@ -206,7 +208,7 @@ const Permissions: React.FC<ActionEditorProps> = ({
                   </ControlRow>
                   {invalid && !!error && <Error>{error}</Error>}
                   <TokenPicker
-                    walletAddress={parsedData?.to || ''}
+                    walletAddress={guildId}
                     isOpen={isTokenPickerOpen}
                     onClose={() => setIsTokenPickerOpen(false)}
                     onSelect={asset => {


### PR DESCRIPTION
# Description

These token pickers are always wanting to show the DAO's holdings in this case so we can just pass the guild ID as in permission registry's picker we see the user's holdings

Closes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
