### PR TITLE
fix: Remove global error boundary.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import App from './App';
 import initializeI18Next from './i18n';
-import { GlobalErrorBoundary } from './components/ErrorBoundary';
 import * as serviceWorker from './serviceWorker';
 import moment from 'moment';
 import { EtherSWRManager } from 'components/EtherSWRManager';
@@ -35,20 +34,18 @@ moment.updateLocale('en', {
 
 const Root = () => {
   return (
-    <GlobalErrorBoundary>
-      <WagmiConfig client={client}>
-        <HashRouter>
-          <SyncRouterWithWagmi>
-            <EtherSWRManager>
-              <>
-                <App />
-                <EnsureReadOnlyConnection />
-              </>
-            </EtherSWRManager>
-          </SyncRouterWithWagmi>
-        </HashRouter>
-      </WagmiConfig>
-    </GlobalErrorBoundary>
+    <WagmiConfig client={client}>
+      <HashRouter>
+        <SyncRouterWithWagmi>
+          <EtherSWRManager>
+            <>
+              <App />
+              <EnsureReadOnlyConnection />
+            </>
+          </EtherSWRManager>
+        </SyncRouterWithWagmi>
+      </HashRouter>
+    </WagmiConfig>
   );
 };
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
# Description

The global error boundary was a bit trigger happy and was getting triggered unnecessarily. The Global error boundary was initially added to show a warning on DXvote when the cache loading fails and no longer is relevant. I think we should implement localized error boundaries at some point instead of having a global one.

On a separate issue, the app seems to try to connect to localhost RPCs somewhere in our code and fails with an unhandled exception, which I believe in turn triggered the error boundary. This should be investigated later and might even be solved after the recent refactors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on preview deployments.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
