### PR TITLE
Added cypress dashboard for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,9 +52,9 @@ jobs:
 
       - name: Run Synpress with dashboard
         if: ${{ needs.check-if-tests-should-run.outcome == 'success' || (github.event_name == 'push') }}
-        run: yarn run test:e2e record
+        run: yarn run test:e2e
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.DASHBOARD_KEY }}
+          DASHBOARD_KEY: ${{ secrets.DASHBOARD_KEY }}
 
       - name: Run Synpress without dashboard
         if: ${{ needs.check-if-tests-should-run.outcome != 'success' && !(github.event_name == 'push')}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,19 @@ jobs:
         run: |
           echo -e 'pcm.!default {\n type hw\n card 0\n}\n\nctl.!default {\n type hw\n card 0\n}' > ~/.asoundrc
 
-      - name: Run Synpress
-        run: yarn run test:e2e
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        id: check-if-tests-should-run
+        continue-on-error: true
+        with:
+          one_of: ready-for-tests, QA
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run Synpress with dashboard
+        if: ${{ needs.check-if-tests-should-run.outcome == 'success' || (github.event_name == 'push') }}
+        run: yarn run test:e2e record
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.DASHBOARD_KEY }}
+
+      - name: Run Synpress without dashboard
+        if: ${{ needs.check-if-tests-should-run.outcome != 'success' && !(github.event_name == 'push')}}
+        run: yarn run test:e2e

--- a/cypress/config/development.json
+++ b/cypress/config/development.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "http://localhost:3000/#",
-  "projectId": "bocbgz",
+  "projectId": "zps4ub",
   "experimentalStudio": true,
   "viewportWidth": 1920,
   "viewportHeight": 1080,

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# Get record key from env
-# export $(grep -v '^#' .env | xargs)
-# RECORD_KEY="${CYPRESS_RECORD_KEY}"
-
 export SECRET_WORDS="cream core pear sure dinner indoor citizen divorce sudden captain subject remember"
 export PASSWORD="TestMetaMask"
 export NETWORK_NAME=localhost
@@ -16,5 +12,8 @@ export FAIL_ON_ERROR=0
 # export SKIP_METAMASK_INSTALL=false
 # export SKIP_METAMASK_SETUP=false
 
-synpress run --configFile ./cypress/config/development.json
-# TODO: Include monitoring  with record key like: synpress run --configFile synpress.json --record --key $RECORD_KEY
+if [[ $CYPRESS_RECORD_KEY ]]; then
+  synpress run --configFile ./cypress/config/development.json --record --key $CYPRESS_RECORD_KEY
+else
+  synpress run --configFile ./cypress/config/development.json
+fi

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -12,8 +12,8 @@ export FAIL_ON_ERROR=0
 # export SKIP_METAMASK_INSTALL=false
 # export SKIP_METAMASK_SETUP=false
 
-if [[ $CYPRESS_RECORD_KEY ]]; then
-  synpress run --configFile ./cypress/config/development.json --record --key $CYPRESS_RECORD_KEY
+if [[ $DASHBOARD_KEY ]]; then
+  synpress run --configFile ./cypress/config/development.json --record --key $DASHBOARD_KEY
 else
   synpress run --configFile ./cypress/config/development.json
 fi


### PR DESCRIPTION
# Description

This pr contains added cypress dashboard for synpress tests. It will only use the Dashboard on merging to the develop and when the pr contains either ready-for-tests or QA label.

Right now we got a litlle problem with test capacity in cypress dashboard, but as soon as the sorry-cypress will be implemented in synpress we will switch to them and use bunch of stuff like parallelisation etc.