### PR TITLE
hotfix: fetch discussions

### DIFF
--- a/src/Modules/Social/Discussions.tsx
+++ b/src/Modules/Social/Discussions.tsx
@@ -30,7 +30,7 @@ const Discussions = () => {
 
   const getDiscussions = async (page: number = 0) => {
     setIsLoading(true);
-    let { data, error } = await orbis.current.getPosts(
+    let { data, error } = await orbis.getPosts(
       {
         algorithm: 'all-context-master-posts',
         context: guildId,


### PR DESCRIPTION
# Description

When removed `useRef` didn't delete the `current` property from the `orbis` object, causing an error while fetching discussions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
