### PR TITLE
Display winning option

### DIFF
--- a/src/Modules/Guilds/Wrappers/ProposalCardWrapper.tsx
+++ b/src/Modules/Guilds/Wrappers/ProposalCardWrapper.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useTypedParams } from '../Hooks/useTypedParams';
 import { ProposalCard } from 'components/ProposalCard';
 import useENSAvatar from 'hooks/Guilds/ens/useENSAvatar';
@@ -21,21 +20,6 @@ const ProposalCardWrapper: React.FC<ProposalCardWrapperProps> = ({
   const { withFilters } = useFilter();
   const { options } = useProposalCalls(guildId, proposalId);
 
-  const sortedOptionsByWinningVotes = useMemo(() => {
-    if (options) {
-      const sortedOptionsByWiningVote: any = options?.sort((a, b) => {
-        const aVotes = a.totalVotes?.toBigInt();
-        const bVotes = b.totalVotes?.toBigInt();
-        if (aVotes === bVotes) return 0;
-        if (aVotes < bVotes) return 1;
-        return -1;
-      });
-      return sortedOptionsByWiningVote;
-    } else {
-      return [];
-    }
-  }, [options]);
-
   return withFilters(
     <ProposalCard
       proposal={{ ...proposal, id: proposalId }}
@@ -48,7 +32,7 @@ const ProposalCardWrapper: React.FC<ProposalCardWrapperProps> = ({
         status,
         endTime: proposal?.endTime,
       }}
-      options={sortedOptionsByWinningVotes}
+      options={options}
     />
   )(proposal, status, options);
 };

--- a/src/Modules/Guilds/pages/AllProposals/AllProposals.tsx
+++ b/src/Modules/Guilds/pages/AllProposals/AllProposals.tsx
@@ -61,7 +61,7 @@ const AllProposals = ({ guildId }) => {
     return (
       <Result
         state={ResultState.ERROR}
-        title={t('genericProposalError')}
+        title={t('errorMessage.genericProposalError')}
         subtitle={error.message}
       />
     );

--- a/src/Modules/Guilds/pages/Governance/Governance.tsx
+++ b/src/Modules/Guilds/pages/Governance/Governance.tsx
@@ -76,7 +76,7 @@ const Governance = ({ guildId }) => {
     return (
       <Result
         state={ResultState.ERROR}
-        title={t('genericProposalError')}
+        title={t('errorMessage.genericProposalError')}
         subtitle={error.message}
       />
     );

--- a/src/Modules/Guilds/pages/Proposal/Proposal.tsx
+++ b/src/Modules/Guilds/pages/Proposal/Proposal.tsx
@@ -95,7 +95,7 @@ const ProposalPage: React.FC = () => {
       return (
         <Result
           state={ResultState.ERROR}
-          title={t('genericProposalError')}
+          title={t('errorMessage.genericProposalError')}
           subtitle={error.message}
         />
       );

--- a/src/components/ProposalCard/ProposalCard.tsx
+++ b/src/components/ProposalCard/ProposalCard.tsx
@@ -54,7 +54,7 @@ export const ProposalCard: React.FC<ProposalCardProps> = ({
           </CardTitle>
         </CardContent>
         <CardFooter>
-          {options && <ProposalCardWinningOption option={options[0]} />}
+          <ProposalCardWinningOption options={options} />
         </CardFooter>
       </ProposalCardWrapper>
     </UnstyledLink>

--- a/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.test.tsx
+++ b/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.test.tsx
@@ -42,26 +42,26 @@ jest.mock('wagmi', () => ({
 describe('ProposalCardWinningOption', () => {
   it('renders properly with one action', () => {
     const { container } = render(
-      <ProposalCardWinningOption option={optionsMock} />
+      <ProposalCardWinningOption options={[optionsMock]} />
     );
     expect(container).toMatchSnapshot();
   });
 
   it('renders loading component when there are no options', () => {
-    const { container } = render(<ProposalCardWinningOption option={null} />);
+    const { container } = render(<ProposalCardWinningOption options={null} />);
     expect(container).toMatchSnapshot();
   });
 
   it('renders a loading component when the votes are not fetched yet', () => {
     const { container } = render(
-      <ProposalCardWinningOption option={optionWithoutVotes} />
+      <ProposalCardWinningOption options={[optionWithoutVotes]} />
     );
     expect(container).toMatchSnapshot();
   });
 
   it('renders an indicator of the number of actions if the option has more than one action', async () => {
     const { container, findByText } = render(
-      <ProposalCardWinningOption option={optionsWithSeveralActionsMock} />
+      <ProposalCardWinningOption options={[optionsWithSeveralActionsMock]} />
     );
 
     const numberOfActions = await findByText('2');
@@ -74,7 +74,7 @@ describe('ProposalCardWinningOption', () => {
 
   it('a tooltip shows after clicking in the action idicator when there are more than one action', async () => {
     const { container, findByLabelText } = render(
-      <ProposalCardWinningOption option={optionsWithSeveralActionsMock} />
+      <ProposalCardWinningOption options={[optionsWithSeveralActionsMock]} />
     );
 
     const expandActionsList: HTMLElement = await findByLabelText(
@@ -92,7 +92,7 @@ describe('ProposalCardWinningOption', () => {
 
   it('if the option has only one action, no tooltip shows after clicking it', async () => {
     const { container, findByLabelText, queryByLabelText } = render(
-      <ProposalCardWinningOption option={optionsMock} />
+      <ProposalCardWinningOption options={[optionsMock]} />
     );
 
     const expandActionsList: HTMLElement = await findByLabelText(

--- a/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.tsx
+++ b/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.tsx
@@ -8,16 +8,27 @@ import {
 } from './ProposalCardWinningOption.styled';
 import { getInfoLineView } from 'components/ActionsBuilder/SupportedActions';
 import UndecodableCallInfoLine from 'components/ActionsBuilder/UndecodableCalls/UndecodableCallInfoLine';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExpandedActionsList } from '../ExpandedActionsList';
 import { ProposalCardWinningOptionProps } from './types';
 
 const ProposalCardWinningOption: React.FC<ProposalCardWinningOptionProps> = ({
-  option,
+  options,
 }) => {
   const [expandedActionsVisible, setExpandedActionsVisible] = useState(false);
   const { t } = useTranslation();
+
+  const option = useMemo(() => {
+    if (!options) return null;
+    return options?.reduce(
+      (acc, option) =>
+        option.totalVotes?.toBigInt() > acc?.totalVotes.toBigInt()
+          ? option
+          : acc,
+      options[0]
+    );
+  }, [options]);
 
   if (!option) {
     return (

--- a/src/components/ProposalCard/ProposalCardWinningOption/types.ts
+++ b/src/components/ProposalCard/ProposalCardWinningOption/types.ts
@@ -1,5 +1,6 @@
 import { Option } from 'components/ActionsBuilder/types';
 
 export interface ProposalCardWinningOptionProps {
-  option: Option;
+  // option: Option;
+  options: Option[];
 }

--- a/src/components/ProposalCard/ProposalCardWinningOption/types.ts
+++ b/src/components/ProposalCard/ProposalCardWinningOption/types.ts
@@ -1,6 +1,5 @@
 import { Option } from 'components/ActionsBuilder/types';
 
 export interface ProposalCardWinningOptionProps {
-  // option: Option;
   options: Option[];
 }

--- a/src/components/ProposalCard/__snapshots__/ProposalCard.test.tsx.snap
+++ b/src/components/ProposalCard/__snapshots__/ProposalCard.test.tsx.snap
@@ -1721,7 +1721,25 @@ exports[`ProposalCard ProposalCard loading 1`] = `
       </div>
       <div
         class="c1 c13"
-      />
+      >
+        <div
+          class=""
+          style="margin: 0px;"
+        >
+          <span
+            aria-busy="true"
+            aria-live="polite"
+          >
+            <span
+              class="react-loading-skeleton"
+              style="width: 200px; --base-color: #333; --highlight-color: #555;"
+            >
+              ‌
+            </span>
+            <br />
+          </span>
+        </div>
+      </div>
     </div>
   </a>
    

--- a/src/hooks/Guilds/erc20/useERC20Info.test.ts
+++ b/src/hooks/Guilds/erc20/useERC20Info.test.ts
@@ -21,17 +21,7 @@ describe('useERC20Info', () => {
   });
   it('should return ERC20Info', () => {
     const { data, isError, isLoading } = useERC20Info(MOCK_CONTRACT_ADDRESS);
-    expect(data).toMatchInlineSnapshot(`
-      Object {
-        "decimals": 0,
-        "name": "WAGMI",
-        "symbol": "WAG",
-        "totalSupply": Object {
-          "hex": "0x64",
-          "type": "BigNumber",
-        },
-      }
-    `);
+    expect(data).toMatchInlineSnapshot(`undefined`);
     expect(isError).toBe(false);
     expect(isLoading).toBe(false);
   });

--- a/src/hooks/Guilds/erc20/useERC20Info.test.ts
+++ b/src/hooks/Guilds/erc20/useERC20Info.test.ts
@@ -21,7 +21,17 @@ describe('useERC20Info', () => {
   });
   it('should return ERC20Info', () => {
     const { data, isError, isLoading } = useERC20Info(MOCK_CONTRACT_ADDRESS);
-    expect(data).toMatchInlineSnapshot(`undefined`);
+    expect(data).toMatchInlineSnapshot(`
+    Object {
+      "decimals": 0,
+      "name": "WAGMI",
+      "symbol": "WAG",
+      "totalSupply": Object {
+        "hex": "0x64",
+        "type": "BigNumber",
+      },
+    }
+  `);
     expect(isError).toBe(false);
     expect(isLoading).toBe(false);
   });

--- a/src/hooks/Guilds/erc20/useERC20Info.ts
+++ b/src/hooks/Guilds/erc20/useERC20Info.ts
@@ -40,7 +40,7 @@ export const useERC20Info = (contractAddress: string): ERC20InfoHook => {
       },
     ],
   });
-  if (!data || data.some(v => !v)) {
+  if (!data || data.some(v => v === null)) {
     return { data: undefined, isError, isLoading };
   }
   return {

--- a/src/hooks/Guilds/erc20/useERC20Info.ts
+++ b/src/hooks/Guilds/erc20/useERC20Info.ts
@@ -40,7 +40,7 @@ export const useERC20Info = (contractAddress: string): ERC20InfoHook => {
       },
     ],
   });
-  if (!data || data.every(v => v === null)) {
+  if (!data || data.some(v => !v)) {
     return { data: undefined, isError, isLoading };
   }
   return {


### PR DESCRIPTION
# Description
- Display wining option if any. By default show option index 0. Previously we were ordering options at card wrapper level. Since choosing wining option seems to be concern from `ProposalCardWinningOption` I refactored it so it handles that logic.

- While I was testing I found 2 issues/warnings: 
   1. useERC20Info hook braking the app because of this line ` totalSupply: BigNumber.from(data[3]),` where data[3] was null. 
   2. missing translation key (wrong path to key)


Closes https://github.com/DXgovernance/DAVI/issues/277

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
