### PR TITLE
Hotfix: Fixing total locked in snapshot guild

### DIFF
--- a/src/Modules/Guilds/Hooks/useProposal.ts
+++ b/src/Modules/Guilds/Hooks/useProposal.ts
@@ -40,7 +40,7 @@ const useProposal = (guildId: string, proposalId: string) => {
     addressOrName: guildId,
     contractInterface: ERC20GuildContract.abi,
     functionName: 'getProposal',
-    args: proposalId ? proposalId : null,
+    args: proposalId,
     watch: true,
   });
   const proposalData = data as unknown as InitialProposal;

--- a/src/Modules/Guilds/Hooks/useProposal.ts
+++ b/src/Modules/Guilds/Hooks/useProposal.ts
@@ -40,7 +40,7 @@ const useProposal = (guildId: string, proposalId: string) => {
     addressOrName: guildId,
     contractInterface: ERC20GuildContract.abi,
     functionName: 'getProposal',
-    args: [proposalId],
+    args: proposalId ? proposalId : null,
     watch: true,
   });
   const proposalData = data as unknown as InitialProposal;

--- a/src/Modules/Guilds/Hooks/useTotalLocked.ts
+++ b/src/Modules/Guilds/Hooks/useTotalLocked.ts
@@ -1,4 +1,3 @@
-import useCurrentSnapshotId from './useCurrentSnapshotId';
 import useGuildToken from 'Modules/Guilds/Hooks/useGuildToken';
 import useTotalSupplyAt from 'Modules/Guilds/Hooks/useTotalSupplyAt';
 import { useTypedParams } from 'Modules/Guilds/Hooks/useTypedParams';
@@ -11,18 +10,13 @@ import { BigNumber } from 'ethers';
 
 const useTotalLocked = (guildAddress: string, snapshotId?: string) => {
   // Hooks call
-  const { data: currentSnapshotId } = useCurrentSnapshotId({
-    contractAddress: guildAddress,
-  });
-
   const { proposalId } = useTypedParams();
   const { data: _snapshotId } = useSnapshotId({
     contractAddress: guildAddress,
     proposalId,
   });
 
-  const SNAPSHOT_ID =
-    snapshotId ?? _snapshotId?.toString() ?? currentSnapshotId?.toString();
+  const SNAPSHOT_ID = snapshotId ?? _snapshotId?.toString() ?? null;
 
   const { isSnapshotGuild, isRepGuild } =
     useGuildImplementationType(guildAddress);
@@ -63,11 +57,17 @@ const useTotalLocked = (guildAddress: string, snapshotId?: string) => {
   }
 
   if (isSnapshotGuild) {
-    return {
-      data: totalLockedAtProposalSnapshotResponse
-        ? BigNumber.from(totalLockedAtProposalSnapshotResponse)
-        : undefined,
-    };
+    return SNAPSHOT_ID
+      ? {
+          data: totalLockedAtProposalSnapshotResponse
+            ? BigNumber.from(totalLockedAtProposalSnapshotResponse)
+            : undefined,
+        }
+      : {
+          data: totalLockedResponse
+            ? BigNumber.from(totalLockedResponse)
+            : undefined,
+        };
   }
   return {
     data: totalLockedResponse ? BigNumber.from(totalLockedResponse) : undefined,

--- a/src/Modules/Guilds/Hooks/useVotingPowerOf.ts
+++ b/src/Modules/Guilds/Hooks/useVotingPowerOf.ts
@@ -35,7 +35,7 @@ export const useVotingPowerOf = ({
     fallbackSnapshotId,
   });
 
-  if (isSnapshotGuild) return votingPowerAtSnapshotResponse;
+  if (isSnapshotGuild && snapshotId) return votingPowerAtSnapshotResponse;
   return {
     data: votingPowerOfResponse
       ? BigNumber.from(votingPowerOfResponse)

--- a/src/components/StakeTokensModal/components/StakeTokensForm/StakeTokensForm.styled.ts
+++ b/src/components/StakeTokensModal/components/StakeTokensForm/StakeTokensForm.styled.ts
@@ -78,7 +78,7 @@ export const InfoValue = styled.span`
 `;
 
 export const InfoOldValue = styled(InfoValue)`
-  color: ${({ theme }) => theme.colors.border1};
+  color: ${({ theme }) => theme.colors.grey};
   display: inline-flex;
   align-items: center;
 `;


### PR DESCRIPTION
# Description

We were getting current snapshot id in a lot of places and using that to get total locked and voting power of. However if we are not looking at a proposal directly we do not want to do this as a new current snapshot id is only ever created once a proposal is made. So we cannot rely on this to get the most up to date token locked state. This resulted in users not being able to lock tokens or join the guild, now fixes. 

Closes #316

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
