### PR TITLE
Fix/remove default value in number input

### DIFF
--- a/src/Modules/Guilds/Hooks/useProposalCalls.ts
+++ b/src/Modules/Guilds/Hooks/useProposalCalls.ts
@@ -6,7 +6,7 @@ import { decodeCall } from 'hooks/Guilds/contracts/useDecodedCall';
 import useProposal from 'Modules/Guilds/Hooks/useProposal';
 import { useVotingResults } from 'Modules/Guilds/Hooks/useVotingResults';
 import { Call, Option } from 'components/ActionsBuilder/types';
-import { ZERO_HASH } from 'utils';
+import { preventEmptyString, ZERO_HASH } from 'utils';
 import useProposalMetadata from 'hooks/Guilds/useProposalMetadata';
 import { useRichContractRegistry } from 'hooks/Guilds/contracts/useRichContractRegistry';
 import { ERC20_APPROVE_SIGNATURE } from 'utils';
@@ -93,7 +93,9 @@ const useProposalCalls = (guildId: string, proposalId: string) => {
       const encodedOptions: Option[] = await Promise.all(
         splitCalls.map(async (calls, index) => {
           const filteredActions = calls.filter(
-            call => !isZeroHash(call?.data) || !call.value?.isZero()
+            call =>
+              !isZeroHash(call?.data) ||
+              !preventEmptyString(call?.value).isZero()
           );
           const actions = await Promise.all(
             filteredActions.map(async call => {

--- a/src/Modules/Guilds/pages/CreateProposal.tsx
+++ b/src/Modules/Guilds/pages/CreateProposal.tsx
@@ -18,7 +18,7 @@ import { FiChevronLeft, FiX } from 'react-icons/fi';
 import { MdOutlinePreview, MdOutlineModeEdit } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import sanitizeHtml from 'sanitize-html';
-import { ZERO_ADDRESS, ZERO_HASH } from 'utils';
+import { preventEmptyString, ZERO_ADDRESS, ZERO_HASH } from 'utils';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from 'styled-components';
 import { toast } from 'react-toastify';
@@ -159,7 +159,7 @@ const CreateProposalPage: React.FC = () => {
 
     const toArray = calls.map(call => call.to);
     const dataArray = calls.map(call => call.data);
-    const valueArray = calls.map(call => call.value);
+    const valueArray = calls.map(call => preventEmptyString(call.value));
 
     if (
       toArray.length === 0 &&

--- a/src/components/ActionsBuilder/Action/Action.tsx
+++ b/src/components/ActionsBuilder/Action/Action.tsx
@@ -24,6 +24,7 @@ import {
 } from './Action.styled';
 import { ConfirmRemoveActionModal } from '../ConfirmRemoveActionModal';
 import { ActionModal } from 'components/ActionsModal';
+import { preventEmptyString } from 'utils';
 
 interface ActionViewProps {
   call?: Call;
@@ -78,8 +79,9 @@ export const ActionRow: React.FC<ActionViewProps> = ({
   const cardStatus: CardStatus = useMemo(() => {
     if (isEditable && isDragging) return CardStatus.dragging;
 
-    const hasValueTransferOnContractCall =
-      decodedCall?.args && decodedCall?.value?.gt(0);
+    let hasValueTransferOnContractCall: boolean =
+      decodedCall?.args && preventEmptyString(decodedCall?.value).gt(0);
+
     if (!decodedCall || hasValueTransferOnContractCall)
       return CardStatus.warning;
 

--- a/src/components/ActionsBuilder/CallDetails/CallDetails.test.tsx
+++ b/src/components/ActionsBuilder/CallDetails/CallDetails.test.tsx
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import { render } from 'utils/tests';
 import { CallDetails } from './CallDetails';
 import {
@@ -5,6 +6,8 @@ import {
   decodedCallMock,
   emptyDecodedCallMock,
 } from './fixtures';
+
+const mockBigNumber = BigNumber.from(0);
 
 jest.mock('hooks/Guilds/ens/useENSAvatar', () => ({
   __esModule: true,
@@ -21,6 +24,7 @@ jest.mock('utils', () => ({
       symbol: 'TST',
     },
   }),
+  preventEmptyString: () => mockBigNumber,
 }));
 
 jest.mock('wagmi', () => ({

--- a/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallInfoLine.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/GenericCall/GenericCallInfoLine.tsx
@@ -13,6 +13,7 @@ import { FiArrowRight, FiCode } from 'react-icons/fi';
 import { ActionViewProps } from '..';
 import GenericCallParamsMatcher from './GenericCallParamsMatcher';
 import { useTranslation } from 'react-i18next';
+import { preventEmptyString } from 'utils';
 
 export interface FunctionParamWithValue extends RichContractFunctionParam {
   value: string;
@@ -26,7 +27,7 @@ const GenericCallInfoLine: React.FC<ActionViewProps> = ({
   const { t } = useTranslation();
   const { data: tokenInfo } = useERC20Info(approveSpendTokens?.token);
   const approvalAmount = useBigNumberToString(
-    approveSpendTokens?.amount,
+    preventEmptyString(approveSpendTokens?.amount),
     tokenInfo?.decimals
   );
   const { functionData } = useRichContractData(decodedCall);

--- a/src/components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.test.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.test.tsx
@@ -241,5 +241,83 @@ describe(`Set Permissions editor`, () => {
         screen.getByRole('textbox', { name: /amount input/i })
       ).toBeInTheDocument();
     });
+
+    it(`Can switch back an forth a couple of times with data`, () => {
+      render(
+        <Permissions
+          decodedCall={completeDecodedCallMock}
+          onSubmit={jest.fn()}
+        />
+      );
+
+      const functionsCallTab = screen.getByTestId(`functions-call-tab`);
+      const assetTransferTab = screen.getByTestId(`asset-transfer-tab`);
+
+      fireEvent.click(functionsCallTab);
+      fireEvent.click(assetTransferTab);
+      fireEvent.click(functionsCallTab);
+
+      const toAddressElement: HTMLInputElement = screen.getByRole('textbox', {
+        name: /to address input/i,
+      });
+
+      const functionNameElement: HTMLInputElement = screen.getByRole(
+        'textbox',
+        { name: /function signature input/i }
+      );
+
+      const customAmountElement: HTMLInputElement = screen.getByRole(
+        'textbox',
+        {
+          name: /amount input/i,
+        }
+      );
+
+      expect(toAddressElement.value).toBe(completeDecodedCallMock.args.to);
+      expect(functionNameElement.value).toBe(functionNameMock);
+      expect(customAmountElement.value).toBe('111.0');
+
+      expect(
+        screen.getByRole('textbox', { name: /to address input/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('textbox', { name: /function signature input/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('textbox', { name: /amount input/i })
+      ).toBeInTheDocument();
+    });
+
+    it(`Can switch back an forth a couple of times without data`, () => {
+      render(
+        <Permissions decodedCall={emptyDecodedCallMock} onSubmit={jest.fn()} />
+      );
+
+      const functionsCallTab = screen.getByTestId(`functions-call-tab`);
+      const assetTransferTab = screen.getByTestId(`asset-transfer-tab`);
+
+      fireEvent.click(functionsCallTab);
+      fireEvent.click(assetTransferTab);
+
+      expect(
+        screen.getByRole('textbox', { name: /asset picker/i })
+      ).toBeInTheDocument();
+
+      fireEvent.click(functionsCallTab);
+
+      expect(
+        screen.getByRole('textbox', { name: /to address input/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('textbox', { name: /function signature input/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('textbox', { name: /amount input/i })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/SetPermissions/SetPermissionsEditor.tsx
@@ -6,7 +6,11 @@ import { Controller, useForm } from 'react-hook-form';
 import { FiChevronDown } from 'react-icons/fi';
 
 import { ParsedDataInterface, TABS } from './types';
-import { ANY_FUNC_SIGNATURE, ERC20_TRANSFER_SIGNATURE } from 'utils';
+import {
+  ANY_FUNC_SIGNATURE,
+  ERC20_TRANSFER_SIGNATURE,
+  preventEmptyString,
+} from 'utils';
 import { resolveUri } from 'utils/url';
 import { ActionEditorProps } from '..';
 import { useTokenList } from 'hooks/Guilds/tokens/useTokenList';
@@ -150,7 +154,10 @@ const Permissions: React.FC<ActionEditorProps> = ({
     const initTab = id === Number(parsedData.tab);
     // reset values
     setValue('toAddress', initTab ? parsedData.to : '');
-    setValue('amount', BigNumber.from(initTab ? parsedData?.valueAllowed : 0));
+    setValue(
+      'amount',
+      BigNumber.from(initTab ? preventEmptyString(parsedData?.valueAllowed) : 0)
+    );
     setValue('functionName', initTab ? parsedData.functionName : '');
     setValue('tokenAddress', initTab ? parsedData.asset : '');
     setValue('functionSignature', initTab ? parsedData.functionSignature : '');

--- a/src/components/ActionsBuilder/SupportedActions/SetPermissions/types.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/SetPermissions/types.tsx
@@ -4,7 +4,7 @@ export interface ParsedDataInterface {
   asset: string;
   to: string;
   functionSignature: string;
-  valueAllowed: BigNumber;
+  valueAllowed: BigNumber | string;
   allowance: boolean;
   functionName: string;
   tab?: number;

--- a/src/components/ActionsBuilder/SupportedActions/common/Summary.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/common/Summary.tsx
@@ -3,7 +3,7 @@ import useENSAvatar from 'hooks/Guilds/ens/useENSAvatar';
 import { Avatar } from 'components/Avatar';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getNetworkById, MAINNET_ID } from 'utils';
+import { getNetworkById, MAINNET_ID, preventEmptyString } from 'utils';
 import { useNetwork } from 'wagmi';
 import { Segment } from './infoLine';
 import {
@@ -19,7 +19,11 @@ import { SupportedAction } from 'components/ActionsBuilder/types';
 
 const Summary = ({ decodedCall, blockExplorerUrl }: SummaryProps) => {
   const { t } = useTranslation();
-  const parsedValueToString = useBigNumberToString(decodedCall?.value, 18);
+
+  const parsedValueToString = useBigNumberToString(
+    preventEmptyString(decodedCall?.value),
+    18
+  );
   const { ensName, imageUrl } = useENSAvatar(decodedCall.to, MAINNET_ID);
   const { chain } = useNetwork();
   const nativeTokenSymbol = useMemo(() => {

--- a/src/components/ActionsBuilder/SupportedActions/index.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/index.tsx
@@ -99,7 +99,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       callType: SupportedAction.NATIVE_TRANSFER,
       function: null,
       to: '',
-      value: BigNumber.from(0),
+      value: '',
       args: null,
     },
   },
@@ -114,7 +114,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       value: BigNumber.from(0),
       args: {
         _to: '',
-        _value: BigNumber.from(0),
+        _value: '',
       },
     },
   },
@@ -129,7 +129,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       value: BigNumber.from(0),
       args: {
         to: '',
-        amount: BigNumber.from(0),
+        amount: '',
       },
     },
   },
@@ -142,7 +142,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       function: null,
       to: '',
       args: {},
-      value: BigNumber.from(0),
+      value: '',
     },
   },
   [SupportedAction.SET_PERMISSIONS]: {
@@ -157,7 +157,7 @@ export const defaultValues: Record<SupportedAction, DecodedAction> = {
       args: {
         to: '',
         functionSignature: '',
-        valueAllowed: BigNumber.from(0),
+        valueAllowed: '',
         allowed: true,
       },
       optionalProps: {

--- a/src/components/ActionsBuilder/types.ts
+++ b/src/components/ActionsBuilder/types.ts
@@ -18,7 +18,7 @@ export interface Call {
   from: string;
   to: string;
   data: string;
-  value: BigNumber;
+  value: BigNumber | string;
   approval?: ApproveSendTokens;
   functionName?: string;
   approvalCall?: Call;
@@ -28,7 +28,7 @@ export interface DecodedCall {
   callType: SupportedAction;
   from: string;
   to: string;
-  value: BigNumber;
+  value: BigNumber | string;
   function: utils.FunctionFragment;
   args: Record<string, any>;
   richData?: RichContractData;
@@ -56,6 +56,6 @@ export interface Option {
 }
 
 export interface ApproveSendTokens extends DecodedCall {
-  amount?: BigNumber;
+  amount?: BigNumber | string;
   token?: string;
 }

--- a/src/components/ActionsModal/components/ApproveSpendTokens/ApproveSpendTokens.tsx
+++ b/src/components/ActionsModal/components/ApproveSpendTokens/ApproveSpendTokens.tsx
@@ -23,9 +23,10 @@ import {
   ControlLabel,
   ControlRow,
 } from 'components/primitives/Forms/Control';
+import { preventEmptyString } from 'utils';
 
 export interface TokenSpendApproval {
-  amount?: BigNumber;
+  amount?: BigNumber | string;
   token?: string;
 }
 
@@ -56,7 +57,7 @@ const ApproveSpendTokens: React.FC<ApproveSpendTokensProps> = ({
 
   useEffect(() => {
     if (defaultValue) {
-      setAmount(defaultValue.amount);
+      setAmount(preventEmptyString(defaultValue.amount));
       setToken(defaultValue.token);
     }
   }, [defaultValue]);

--- a/src/hooks/Guilds/contracts/useEncodedCall.ts
+++ b/src/hooks/Guilds/contracts/useEncodedCall.ts
@@ -1,6 +1,7 @@
 import { Call, DecodedCall, Option } from 'components/ActionsBuilder/types';
 import ERC20 from 'contracts/ERC20.json';
 import { utils, BigNumber } from 'ethers';
+import { preventEmptyString } from 'utils';
 
 export const encodeCall = (
   decodedCall: DecodedCall,
@@ -40,7 +41,7 @@ export const bulkEncodeCallsFromOptions = (options: Option[]): Option[] => {
             to: decodedAction.approval?.token, // Token address
             data: encodeApprovalCall(
               decodedAction.decodedCall.to, // Spender: Contract we are doing the actual spending call to
-              decodedAction.approval?.amount // Value: Amount of tokens to approve
+              preventEmptyString(decodedAction.approval?.amount) // Value: Amount of tokens to approve
             ),
             value: BigNumber.from('0'), // No native tokens to send on approval call
           };

--- a/src/utils/bignumber.ts
+++ b/src/utils/bignumber.ts
@@ -24,7 +24,7 @@ BigNumber.config({
 export const preventEmptyString = (
   value: EthersBigNumber | string
 ): EthersBigNumber => {
-  if (typeof value === 'string') return EthersBigNumber.from(0);
+  if (!value || typeof value === 'string') return EthersBigNumber.from(0);
   else return value;
 };
 

--- a/src/utils/bignumber.ts
+++ b/src/utils/bignumber.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js';
+import { BigNumber as EthersBigNumber } from 'ethers';
 
 BigNumber.config({
   EXPONENTIAL_AT: [-100, 100],
@@ -10,5 +11,21 @@ BigNumber.config({
     decimalSeparator: '.',
   },
 });
+
+/*  Since strictNullChecks is set to false in tsconfig, if a value
+    is null, it'll still be considered valid.
+    Passing a null value to BigNumber throws an error. To circumvent
+    that limitation, a value could either be BigNumber or a string.
+    This function prevents passing a string to a BigNumber method, and
+    is used as a safeguard in cases where a value could be an empty
+    string (not in cases that we actually want to pass a string to
+    convert to BigNumber).
+*/
+export const preventEmptyString = (
+  value: EthersBigNumber | string
+): EthersBigNumber => {
+  if (typeof value === 'string') return EthersBigNumber.from(0);
+  else return value;
+};
 
 export { BigNumber };


### PR DESCRIPTION
# Description

Previously, since we couldn't pass a null value to BigNumber, the default values were set to '0'. This caused that we couldn't set empty input fields that contained values.

Now we can pass an empty string to the value and add `preventEmptyString` to force that value to `BigNumber.from(0)` if it's a string.

I also copy the comment in the `preventEmptyString` function:
Since strictNullChecks is set to false in tsconfig, if a value is null, it'll still be considered valid.
Passing a null value to BigNumber throws an error. To circumvent that limitation, a value could either be BigNumber or a string. This function prevents passing a string to a BigNumber method, and is used as a safeguard in cases where a value could be an empty string (not in cases that we actually want to pass a string to convert to BigNumber).

How to test it:

1. Go to the proposal creation page
2. Add actions that have amounts (transaction, vesting contract, swapr fees)
3. The inputs should appear empty, with only the placeholder showing
4. The number input fields should work as always (with the same validations)

Exceptions:

1. Lock tokens: since this input formats the value into BigNumber every 350ms, it'll still show a "0.0" after that time
2. Set Permissions > Function call: since switching tabs require to format the data to BigNumber, it'll still show "0.0"

Closes #332 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests currently passing. Also added unit tests to check for edge cases.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
