### PR TITLE
Feat: Proposal status pill is colored depending on status

### DIFF
--- a/src/components/ProposalStatus/ProposalStatus.tsx
+++ b/src/components/ProposalStatus/ProposalStatus.tsx
@@ -33,13 +33,33 @@ const ProposalStatusDetail = styled(Box)<{ statusDetail?: ProposalState }>`
   border-radius: 15px;
   border: 1px solid
     ${({ theme, statusDetail }) =>
-      statusDetail === ProposalState.Failed
+      statusDetail === ProposalState.Active
+        ? theme.colors.active
+        : statusDetail === ProposalState.Executable
+        ? theme.colors.primary1
+        : statusDetail === ProposalState.Executed
+        ? theme.colors.grey
+        : statusDetail === ProposalState.Rejected
+        ? theme.colors.red
+        : statusDetail === ProposalState.Failed
         ? theme.colors.failed
+        : statusDetail === ProposalState.Finished
+        ? theme.colors.grey
         : theme.colors.active};
   background-color: ${({ theme }) => theme.colors.bg1};
   color: ${({ theme, statusDetail }) =>
-    statusDetail === ProposalState.Failed
+    statusDetail === ProposalState.Active
+      ? theme.colors.active
+      : statusDetail === ProposalState.Executable
+      ? theme.colors.primary1
+      : statusDetail === ProposalState.Executed
+      ? theme.colors.grey
+      : statusDetail === ProposalState.Rejected
+      ? theme.colors.red
+      : statusDetail === ProposalState.Failed
       ? theme.colors.failed
+      : statusDetail === ProposalState.Finished
+      ? theme.colors.grey
       : theme.colors.active};
   padding: 0.25rem 0.4rem;
 `;


### PR DESCRIPTION
# Description

The proposal status pill has different colors depending on the status.

A change I made from the discussion is that "Executed" proposals are grey instead of a shade of green. I think this de-emphasizes them as they're already past proposals.

![State - active](https://user-images.githubusercontent.com/75996796/193059271-278483f1-d99f-4664-b95c-8e9f6d28015f.png)

![State - executable](https://user-images.githubusercontent.com/75996796/193059323-f72bd341-b42b-4a74-8b86-8f97161fe20d.png)

![State - executed](https://user-images.githubusercontent.com/75996796/193059403-9f700647-974b-43bf-a69c-24121b0e996c.png)

![State - failed](https://user-images.githubusercontent.com/75996796/193089273-d68742e1-6939-4828-a414-8dee0c03690c.png)

![State - rejected](https://user-images.githubusercontent.com/75996796/193059424-224a40ae-cf87-4077-bf2f-7ee1be7b411a.png)

Currently I think there's no way to trigger a "Finished" state, but it is still configured to show a grey pill (the same as "Executed")


Closes #334 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual testing.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
