### PR TITLE
Fix: hide discussions

### DIFF
--- a/src/Modules/Guilds/pages/AllProposals/AllProposals.styled.tsx
+++ b/src/Modules/Guilds/pages/AllProposals/AllProposals.styled.tsx
@@ -8,6 +8,6 @@ export const ProposalsList = styled(Box)`
 export const ProposalListWrapper = styled.div<{ isSearchOpened: boolean }>`
   height: ${({ isSearchOpened }) => (isSearchOpened ? '43vh' : '50vh')};
   @media only screen and (min-width: 768px) {
-    height: ${({ isSearchOpened }) => (isSearchOpened ? '67vh' : '73vh')};
+    height: ${({ isSearchOpened }) => (isSearchOpened ? '66vh' : '72vh')};
   }
 `;

--- a/src/Modules/Guilds/pages/Governance/Governance.tsx
+++ b/src/Modules/Guilds/pages/Governance/Governance.tsx
@@ -94,23 +94,28 @@ const Governance = ({ guildId }) => {
           placeholder={t('searchTitleEnsAddress')}
         />
         {isProposalCreationAllowed && (
+          <UnstyledLink to={`/${chainName}/${guildId}/create-proposal`}>
+            <StyledButton
+              variant="secondary"
+              data-testid="create-proposal-button"
+            >
+              {t('createProposal')}
+            </StyledButton>
+          </UnstyledLink>
+        )}
+        {process.env.NODE_ENV !== 'production' && (
           <>
-            <UnstyledLink to={`/${chainName}/${guildId}/create-proposal`}>
-              <StyledButton
-                variant="secondary"
-                data-testid="create-proposal-button"
-              >
-                {t('createProposal')}
-              </StyledButton>
-            </UnstyledLink>
             /
+            <UnstyledLink to={`/${chainName}/${guildId}/create`}>
+              <Button
+                variant="secondary"
+                data-testid="create-discussion-button"
+              >
+                {t('forum.createDiscussion')}
+              </Button>
+            </UnstyledLink>
           </>
         )}
-        <UnstyledLink to={`/${chainName}/${guildId}/create`}>
-          <Button variant="secondary" data-testid="create-discussion-button">
-            {t('forum.createDiscussion')}
-          </Button>
-        </UnstyledLink>
       </Flex>
       <ProposalsList data-testid="proposals-list">
         <StyledHeading size={2}>{t('proposals')}</StyledHeading>
@@ -138,10 +143,12 @@ const Governance = ({ guildId }) => {
           </>
         )}
       </ProposalsList>
-      <ProposalsList>
-        <StyledHeading size={2}>{t('forum.discussions_other')}</StyledHeading>
-        <Discussions />
-      </ProposalsList>
+      {process.env.NODE_ENV !== 'production' && (
+        <ProposalsList>
+          <StyledHeading size={2}>{t('forum.discussions_other')}</StyledHeading>
+          <Discussions />
+        </ProposalsList>
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Description

Hide "Discussions" features behind flag:

1. "Create Discussion" button at the top of the page
2. "Discussions" section in the "Governance" page

Discussions should be visible anywhere but in the production environment.

Also fixed a vertical scrollbar in "All proposals" page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
