### PR TITLE
Fix: component breaks after decimal value

### DIFF
--- a/src/components/ActionsModal/components/ParamsForm/FormElementRenderer.tsx
+++ b/src/components/ActionsModal/components/ParamsForm/FormElementRenderer.tsx
@@ -6,6 +6,7 @@ import { RegisterOptions } from 'react-hook-form';
 import { RichContractFunctionParam } from 'hooks/Guilds/contracts/useRichContractRegistry';
 import { isAddress } from 'utils';
 import { AddressInput } from 'components/primitives/Forms/AddressInput';
+import { IntegerInput } from 'components/primitives/Forms/IntegerInput';
 import { FormElementProps } from 'components/primitives/Forms/types';
 import { DateInput, InputType } from 'components/primitives/Forms/DateInput';
 import { Input } from 'components/primitives/Forms/Input';
@@ -30,6 +31,7 @@ const FormElementRenderer: React.FC<FormElementRendererProps> = ({
       case 'address':
         return AddressInput;
       case 'integer':
+        return IntegerInput;
       case 'decimal':
         return NumericalInput;
       case 'date':

--- a/src/components/primitives/Forms/IntegerInput/IntegerInput.stories.tsx
+++ b/src/components/primitives/Forms/IntegerInput/IntegerInput.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { useState } from 'react';
+import { IntegerInput } from './IntegerInput';
+
+export default {
+  title: 'IntegerInput',
+  component: IntegerInput,
+  argTypes: {
+    value: {
+      description: 'value',
+    },
+    onChange: {
+      description:
+        'method that gets triggered when the value of the input changes',
+    },
+  },
+} as ComponentMeta<typeof IntegerInput>;
+
+const StateWrapper = () => {
+  const [value, setValue] = useState('');
+  const onChange = (e: string) => setValue(e);
+  return <IntegerInput value={value} onChange={onChange} />;
+};
+
+const Template: ComponentStory<typeof IntegerInput> = () => <StateWrapper />;
+
+export const Simple = Template.bind({});

--- a/src/components/primitives/Forms/IntegerInput/IntegerInput.test.tsx
+++ b/src/components/primitives/Forms/IntegerInput/IntegerInput.test.tsx
@@ -1,0 +1,71 @@
+import { render } from 'utils/tests';
+import { IntegerInput } from './IntegerInput';
+import { fireEvent, screen } from '@testing-library/react';
+
+describe('IntegerInput', () => {
+  it('should prevent users from inputting a dot (.)', async () => {
+    let value = '';
+    const mockOnChange = jest.fn();
+    render(
+      <IntegerInput
+        value={value}
+        onChange={mockOnChange}
+        name={'integer input'}
+      />
+    );
+
+    const integerField: HTMLInputElement = screen.getByRole('textbox');
+    fireEvent.change(integerField, { target: { value: '1.05' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith('105');
+  });
+
+  it('should prevent users from inputting a comma (,)', async () => {
+    let value = '';
+    const mockOnChange = jest.fn();
+    render(
+      <IntegerInput
+        value={value}
+        onChange={mockOnChange}
+        name={'integer input'}
+      />
+    );
+
+    const integerField: HTMLInputElement = screen.getByRole('textbox');
+    fireEvent.change(integerField, { target: { value: '1,05' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith('105');
+  });
+
+  it('should parse a value passed to it correctly', async () => {
+    let value = '105';
+    const mockOnChange = jest.fn();
+    render(
+      <IntegerInput
+        value={value}
+        onChange={mockOnChange}
+        name={'integer input'}
+      />
+    );
+
+    const integerField: HTMLInputElement = screen.getByRole('textbox');
+
+    expect(integerField.value).toBe('105');
+  });
+
+  it('should sanitize a value with a dot', async () => {
+    let value = '1.05';
+    const mockOnChange = jest.fn();
+    render(
+      <IntegerInput
+        value={value}
+        onChange={mockOnChange}
+        name={'integer input'}
+      />
+    );
+
+    const integerField: HTMLInputElement = screen.getByRole('textbox');
+
+    expect(integerField.value).toBe('105');
+  });
+});

--- a/src/components/primitives/Forms/IntegerInput/IntegerInput.tsx
+++ b/src/components/primitives/Forms/IntegerInput/IntegerInput.tsx
@@ -1,0 +1,18 @@
+import { InputProps } from 'components/primitives/Forms/Input';
+import { NumericalInput } from '../NumericalInput';
+
+export const IntegerInput: React.FC<InputProps<string>> = ({
+  value,
+  onChange,
+  placeholder,
+  ...rest
+}) => {
+  return (
+    <NumericalInput
+      {...rest}
+      value={value.replace('.', '')}
+      onChange={input => onChange(input.replace('.', ''))}
+      placeholder={placeholder || '0'}
+    />
+  );
+};

--- a/src/components/primitives/Forms/IntegerInput/index.ts
+++ b/src/components/primitives/Forms/IntegerInput/index.ts
@@ -1,0 +1,1 @@
+export { IntegerInput } from './IntegerInput';


### PR DESCRIPTION
# Description

Added a new component: `<IntegerInput>` that takes the implementation of `<NumericalInput>` but prevents the user from inputting dots.

An alternative would've been to add a prop to `NumericalInput`, but `FormElementRenderer` doesn't accept components with props.

Closes #410 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Go to the proposal creation page
2. Add a new action: "Swapr fee"
3. The component to input the fee is an `IntegerInput`
4. It shouldn't let a user input anything but numbers

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
