### PR TITLE
Locktime & proposalTime error label fix

### DIFF
--- a/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/SetGuildConfigEditor.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/SetGuildConfigEditor.tsx
@@ -260,6 +260,7 @@ const SetGuildConfigEditor: FC<ActionEditorProps> = ({
                         onChange={handleChange}
                         isInvalid={!!error}
                         icon={f.type === FieldType.percentage && <>%</>}
+                        displayClearIcon={false}
                         iconRight={
                           valueChanged && (
                             <Button

--- a/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/SetGuildConfigEditor.tsx
+++ b/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/SetGuildConfigEditor.tsx
@@ -123,7 +123,7 @@ const SetGuildConfigEditor: FC<ActionEditorProps> = ({
     trigger,
   } = useForm({
     resolver: validateSetGuildConfig,
-    context: { t },
+    context: { t, currentGuildConfig },
     defaultValues: {
       proposalTime: parsedData.proposalTime,
       timeForExecution: parsedData.timeForExecution,

--- a/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/__snapshots__/SetGuildConfigEditor.test.tsx.snap
+++ b/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/__snapshots__/SetGuildConfigEditor.test.tsx.snap
@@ -112,18 +112,6 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
   margin-left: 0.3rem;
 }
 
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-}
-
 .c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -167,7 +155,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
   color: #303338;
 }
 
-.c11 {
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -193,17 +181,17 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
   margin: 1rem 0 0;
 }
 
-.c11:disabled {
+.c10:disabled {
   color: initial;
   opacity: 0.4;
   cursor: auto;
 }
 
-.c11:hover:enabled {
+.c10:hover:enabled {
   border-color: #fff;
 }
 
-.c11:active:enabled {
+.c10:active:enabled {
   border: 1px solid #303338;
 }
 
@@ -303,38 +291,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -376,38 +333,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -447,38 +373,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -518,38 +413,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -589,38 +453,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -682,38 +515,7 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -753,44 +555,13 @@ exports[`SetGuildConfigEditor Should match snapshot 1`] = `
             />
             <div
               class="c9"
-            >
-              <div
-                aria-label="clear number"
-                class="c0 c10"
-                data-testid="clear number"
-              >
-                <svg
-                  fill="none"
-                  height="18"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <line
-                    x1="18"
-                    x2="6"
-                    y1="6"
-                    y2="18"
-                  />
-                  <line
-                    x1="6"
-                    x2="18"
-                    y1="6"
-                    y2="18"
-                  />
-                </svg>
-              </div>
-            </div>
+            />
           </div>
         </div>
       </div>
     </div>
     <button
-      class="c11"
+      class="c10"
       type="submit"
     >
       saveAction

--- a/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/validateSetGuildConfig.ts
+++ b/src/components/ActionsBuilder/SupportedActions/SetGuildConfig/validateSetGuildConfig.ts
@@ -2,16 +2,18 @@ import { TFunction } from 'react-i18next';
 import { SetGuildConfigFields } from './types';
 import { bn } from 'utils/safeBn';
 import { removeNullValues } from 'utils/object';
+import { GuildConfigProps } from 'Modules/Guilds/Hooks/useGuildConfig';
 
 interface Context {
   t: TFunction;
+  currentGuildConfig: GuildConfigProps;
 }
 
 interface SetGuildConfigValues extends SetGuildConfigFields {}
 
 const validateSetGuildConfig = (
   values: SetGuildConfigValues,
-  { t }: Context
+  { t, currentGuildConfig }: Context
 ) => {
   const {
     proposalTime,
@@ -38,8 +40,12 @@ const validateSetGuildConfig = (
   }
 
   if (bn(lockTime).lt(bn(proposalTime))) {
-    errors.lockTime = t('lockTimeHasToBeHigherOrEqualToProposalTime');
-    errors.proposalTime = t('lockTimeHasToBeHigherOrEqualToProposalTime');
+    if (!bn(lockTime).eq(currentGuildConfig.lockTime)) {
+      errors.lockTime = t('lockTimeHasToBeHigherOrEqualToProposalTime');
+    }
+    if (!bn(proposalTime).eq(currentGuildConfig.proposalTime)) {
+      errors.proposalTime = t('proposalTimeHasToBeLowerOrEqualToLockTime');
+    }
   }
 
   if (bn(votingPowerPercentageForProposalExecution).lte(bn(0))) {

--- a/src/components/primitives/Forms/DurationInput/DurationInput.tsx
+++ b/src/components/primitives/Forms/DurationInput/DurationInput.tsx
@@ -78,6 +78,7 @@ const DurationInput: React.FC<DurationInputProps> = ({
                     id={durationKey}
                     muted={count === 0 ? true : false}
                     ariaLabel={`Numerical input for ${durationKey}`}
+                    displayClearIcon={false}
                   />
                   <ColumnButton
                     onClick={() => decrement(durationKey)}

--- a/src/components/primitives/Forms/Input/Input.tsx
+++ b/src/components/primitives/Forms/Input/Input.tsx
@@ -78,6 +78,7 @@ export interface InputProps<T>
   muted?: boolean;
   defaultValue?: string;
   ariaLabel?: string;
+  displayClearIcon?: boolean;
 }
 
 export const Input: React.FC<InputProps<any>> = ({

--- a/src/components/primitives/Forms/NumericalInput.tsx
+++ b/src/components/primitives/Forms/NumericalInput.tsx
@@ -15,6 +15,8 @@ export const NumericalInput: React.FC<InputProps<string>> = ({
   defaultValue,
   ariaLabel,
   isInvalid = false,
+  iconRight = null,
+  displayClearIcon = true,
   ...rest
 }) => {
   const enforcer = (nextUserInput: string) => {
@@ -55,7 +57,13 @@ export const NumericalInput: React.FC<InputProps<string>> = ({
       maxLength={79}
       spellCheck="false"
       disabled={disabledState}
-      iconRight={<IconRight {...iconRightProps} />}
+      iconRight={
+        iconRight ? (
+          iconRight
+        ) : displayClearIcon ? (
+          <IconRight {...iconRightProps} />
+        ) : null
+      }
       aria-label={ariaLabel ? ariaLabel : 'numerical input'}
       isInvalid={isInvalid}
     />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -271,7 +271,7 @@
   "noValueHasBeenUpdatedFromCurrentGuildConfig": "No value has been updated from current guild config",
   "proposalTimeHasToBeMoreThanZero": "Proposal time has to be more than 0",
   "lockTimeHasToBeHigherOrEqualToProposalTime": "Lock time has to be higher or equal to proposal time",
-  "proposalTimeHasToBeLowerOrEqualToLockTime": "Proposal time has to be lower or equal to Lock time",
+  "proposalTimeHasToBeLowerOrEqualToLockTime": "Proposal time has to be lower than or equal to the Lock time",
   "votingPowerPercentageForProposalExecutionHasToBeMoreThanZero": "Voting power percentage for execution has to be more than 0",
   "voteGasHasToBeEqualOrLowerThan117000": "vote gas has to be equal or lower than 117000",
   "setGuildConfig": "Set Guild Config",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -271,6 +271,7 @@
   "noValueHasBeenUpdatedFromCurrentGuildConfig": "No value has been updated from current guild config",
   "proposalTimeHasToBeMoreThanZero": "Proposal time has to be more than 0",
   "lockTimeHasToBeHigherOrEqualToProposalTime": "Lock time has to be higher or equal to proposal time",
+  "proposalTimeHasToBeLowerOrEqualToLockTime": "Proposal time has to be lower or equal to Lock time",
   "votingPowerPercentageForProposalExecutionHasToBeMoreThanZero": "Voting power percentage for execution has to be more than 0",
   "voteGasHasToBeEqualOrLowerThan117000": "vote gas has to be equal or lower than 117000",
   "setGuildConfig": "Set Guild Config",


### PR DESCRIPTION
# Description
- Add conditional flag to display (or not) X icon on `NumericalInput` component to avoid founded issue.
<img width="609" alt="Screen Shot 2022-11-21 at 14 00 41" src="https://user-images.githubusercontent.com/25844967/203122321-b8d478fd-ad70-45e5-a775-2af8a3f618cb.png">

- Display proper error label on `lockTime` and `proposalTime` fields for setGuildConfig Actions. Only display error for updated field, not both.
<img width="392" alt="Screen Shot 2022-11-21 at 14 19 38" src="https://user-images.githubusercontent.com/25844967/203122419-e340122a-1fb2-451e-ba6e-e7c2e3617265.png">


Closes https://github.com/DXgovernance/DAVI/issues/427

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] My code follows the existing style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
