### PR TITLE
fix: Changes to support subgraph in docker.

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -21,8 +21,8 @@ hardhat_running() {
 start-hardhat_node() {
 
   yarn hardhat compile
-  
-  npx hardhat node > /dev/null &
+
+  npx hardhat node --hostname 0.0.0.0 > /dev/null &
 
   hardhat_pid=$!
 
@@ -37,7 +37,7 @@ start-hardhat_node() {
 
 if hardhat_running; then
   echo "Killing existent hardhat"
-  kill $(lsof -t -i:8545) 
+  kill $(lsof -t -i:8545)
 fi
 
 echo "Starting our own hardhat node instance"


### PR DESCRIPTION
# Description

This changes the hostname of the local hardhat node to 0.0.0.0. This will run the node on all network interfaces, including the one Docker uses. Without this, DAVI Subgraph running on Docker can't access the local hardhat node.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any UI changes have been tested and made responsive for mobile views
