### PR TITLE
Fix: TokenAmountInput auto-formatting issue

### DIFF
--- a/src/components/StakeTokensModal/components/StakeTokensForm/__snapshots__/StakeTokensForm.test.tsx.snap
+++ b/src/components/StakeTokensModal/components/StakeTokensForm/__snapshots__/StakeTokensForm.test.tsx.snap
@@ -436,14 +436,12 @@ exports[`StakeTokensForm StakeTokensForm renders properly 1`] = `
     </div>
     <button
       class="c17 c18"
-      data-testid="approve-token-spending"
+      data-testid="lock-token-spending"
       disabled=""
     >
-      approve
+      Lock
        
       REP
-       
-      spending
     </button>
   </div>
    

--- a/src/components/primitives/Forms/TokenAmountInput.tsx
+++ b/src/components/primitives/Forms/TokenAmountInput.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from 'ethers';
 import useBigNumberToString from 'hooks/Guilds/conversions/useBigNumberToString';
 import useStringToBigNumber from 'hooks/Guilds/conversions/useStringToBigNumber';
-import { useDebounce } from 'hooks/Guilds/useDebounce';
 import { useEffect, useState } from 'react';
 import { InputProps } from 'components/primitives/Forms/Input';
 import { NumericalInput } from 'components/primitives/Forms/NumericalInput';
@@ -19,26 +18,28 @@ export const TokenAmountInput: React.FC<TokenAmountInputProps> = ({
   ...rest
 }) => {
   const [localAmount, setLocalAmount] = useState<string>('');
-  const debouncedLocalAmount = useDebounce(localAmount, 350);
   const localAmountBN = useStringToBigNumber(localAmount, decimals);
 
   const valueAsString = useBigNumberToString(value, decimals);
 
   useEffect(() => {
-    if (localAmount !== valueAsString) {
+    if (localAmount === '' && localAmount !== valueAsString) {
       setLocalAmount(valueAsString);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [valueAsString]);
 
   useEffect(() => {
-    onChange(localAmountBN);
+    if (localAmount && localAmount.endsWith('.')) onChange(null);
+    else onChange(localAmountBN);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedLocalAmount]);
+  }, [localAmount]);
 
   const setAmountEnforceDecimals = (amount: string) => {
     const fraction = amount?.split('.')?.[1];
     if (fraction && fraction?.length > decimals) return;
+    if (amount?.startsWith('.')) return;
 
     setLocalAmount(amount);
   };


### PR DESCRIPTION
# Description

Fixed auto-formatting issue in the `TokenAmountInput` component.

Before: after a delay of 350ms the field will auto-format, adding a dot and a decimal.

Now: it doesn't format it automatically. If the value is invalid (like ending with a dot) it will change the value to `null` and prevent the form from submitting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Go to the new proposal page, and select a new "Transfer" action
2. The "Amount" input shouldn't auto-format, nor let you submit if the number ends with a dot.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
