### PR TITLE
Dxdao-contracts pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "copy-to-clipboard": "^3.3.1",
     "crypto-js": "^4.1.1",
     "diff": "^5.1.0",
-    "dxdao-contracts": "https://github.com/DXgovernance/dxdao-contracts.git#develop",
+    "dxdao-contracts": "https://github.com/DXgovernance/dxdao-contracts.git#50db3f0754b5ea1a46342857b9520fa0c5250221",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-cypress": "^2.12.1",
     "ethers": "^5.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12592,7 +12592,7 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-"dxdao-contracts@https://github.com/DXgovernance/dxdao-contracts.git#develop":
+"dxdao-contracts@https://github.com/DXgovernance/dxdao-contracts.git#50db3f0754b5ea1a46342857b9520fa0c5250221":
   version "1.0.0"
   resolved "https://github.com/DXgovernance/dxdao-contracts.git#50db3f0754b5ea1a46342857b9520fa0c5250221"
   dependencies:


### PR DESCRIPTION
### Description
Use commit hash instead of branch name as pkg dependency. 