### PR TITLE
Fix: proposal text not contained

### DIFF
--- a/src/components/ProposalDescription/ProposalDescription.styled.tsx
+++ b/src/components/ProposalDescription/ProposalDescription.styled.tsx
@@ -4,6 +4,7 @@ export const ProposalDescriptionWrapper = styled.div`
   margin: 1.5rem 0;
   line-height: 1.5;
   font-size: 16px;
-  text-align: justify;
+  word-break: break-word;
+  text-align: left;
   color: ${({ theme }) => theme.colors.grey2};
 `;

--- a/src/components/ProposalDescription/__snapshots__/ProposalDescription.test.tsx.snap
+++ b/src/components/ProposalDescription/__snapshots__/ProposalDescription.test.tsx.snap
@@ -5,7 +5,8 @@ exports[`ProposalDescription Should render an error 1`] = `
   margin: 1.5rem 0;
   line-height: 1.5;
   font-size: 16px;
-  text-align: justify;
+  word-break: break-word;
+  text-align: left;
   color: #BDC0C7;
 }
 
@@ -25,7 +26,8 @@ exports[`ProposalDescription Should render loading if it has no metadata 1`] = `
   margin: 1.5rem 0;
   line-height: 1.5;
   font-size: 16px;
-  text-align: justify;
+  word-break: break-word;
+  text-align: left;
   color: #BDC0C7;
 }
 
@@ -60,7 +62,8 @@ exports[`ProposalDescription Should render with description 1`] = `
   margin: 1.5rem 0;
   line-height: 1.5;
   font-size: 16px;
-  text-align: justify;
+  word-break: break-word;
+  text-align: left;
   color: #BDC0C7;
 }
 


### PR DESCRIPTION
# Description

Long words with no spacing (like long links) in the proposal description were not contained and overlapped with other elements. Also, spacing between words was uneven.

Now it breaks words in multiple lines, and aligns text to the left instead of justified.

## Screenshots

Proposal referenced in the issue:
![image](https://user-images.githubusercontent.com/75996796/206721566-bf247124-6997-45ef-b5ea-97977bb3eff1.png)


Long proposal description with long link (ft. ChatGPT):
![image](https://user-images.githubusercontent.com/75996796/206723279-61956a4a-0ff3-44ac-a406-eaf290d2077e.png)


Closes #438 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Snapshot test.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
