### PR TITLE
Feat: spinner when loading governance type

### DIFF
--- a/src/Modules/Guilds/Hooks/useIsProposalCreationAllowed.test.ts
+++ b/src/Modules/Guilds/Hooks/useIsProposalCreationAllowed.test.ts
@@ -8,8 +8,15 @@ const mockBigNumber = (value: number) => BigNumber.from(value);
 
 const mockAddress = ZERO_ADDRESS;
 jest.mock('wagmi', () => ({
+  chain: {},
   useAccount: () => ({ address: mockAddress }),
 }));
+
+jest.mock('provider/ReadOnlyConnector', () => ({
+  READ_ONLY_CONNECTOR_ID: 'readOnly',
+}));
+
+jest.mock('contexts/Guilds/orbis', () => ({}));
 
 describe('useIsProposalCreationAllowed', () => {
   it('should return true if it has more voting power than required', async () => {

--- a/src/components/ActionsBuilder/CallDetails/CallDetails.test.tsx
+++ b/src/components/ActionsBuilder/CallDetails/CallDetails.test.tsx
@@ -53,6 +53,12 @@ jest.mock('wagmi', () => ({
   }),
 }));
 
+jest.mock('provider/ReadOnlyConnector', () => ({
+  READ_ONLY_CONNECTOR_ID: 'readOnly',
+}));
+
+jest.mock('contexts/Guilds/orbis', () => ({}));
+
 describe('CallDetails', () => {
   it('Should match', () => {
     const { container } = render(<CallDetails decodedCall={decodedCallMock} />);

--- a/src/components/LoadingPage/LoadingPage.styled.ts
+++ b/src/components/LoadingPage/LoadingPage.styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const MainDiv = styled.div`
+  width: fit-content;
+  margin: 0 auto;
+`;
+
+export const LoadingText = styled.p`
+  font-size: 1rem;
+`;

--- a/src/components/LoadingPage/LoadingPage.test.tsx
+++ b/src/components/LoadingPage/LoadingPage.test.tsx
@@ -1,0 +1,37 @@
+import LoadingPage from './LoadingPage';
+import { render } from 'utils/tests';
+import { mockChain } from 'components/Web3Modals/fixtures';
+
+jest.mock('contexts/Guilds/orbis', () => ({}));
+
+jest.mock('wagmi', () => ({
+  chain: {},
+  useAccount: () => ({ isConnected: false }),
+  useNetwork: () => ({ chain: mockChain, chains: [mockChain] }),
+  useSwitchNetwork: () => ({ switchNetwork: jest.fn() }),
+  useConnect: () => ({ connect: jest.fn(), connectors: [] }),
+  useDisconnect: () => ({ disconnect: jest.fn() }),
+}));
+
+jest.mock('provider/ReadOnlyConnector', () => ({
+  READ_ONLY_CONNECTOR_ID: 'readOnly',
+}));
+
+jest.mock('contexts/Guilds/transactions', () => ({
+  useTransactions: () => ({ transactions: [] }),
+}));
+
+jest.mock('provider', () => ({
+  getBlockExplorerUrl: () => null,
+}));
+
+jest.mock('provider/wallets', () => ({
+  isReadOnly: () => true,
+}));
+
+describe('LoadingPage', () => {
+  it('should match snapshot', () => {
+    const { container } = render(<LoadingPage />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/LoadingPage/LoadingPage.tsx
+++ b/src/components/LoadingPage/LoadingPage.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+import GlobalStyle from 'theme/GlobalTheme';
+import { Header } from 'components/Header';
+import { Container } from 'components/primitives/Layout';
+import { Loading } from 'components/primitives/Loading';
+import { LoadingText, MainDiv } from './LoadingPage.styled';
+
+const LoadingPage = () => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <GlobalStyle />
+      <Header />
+      <Container>
+        <MainDiv>
+          <Loading loading={true} iconProps={{ size: 80 }} />
+          <LoadingText>{t('loadingDao')}</LoadingText>
+        </MainDiv>
+      </Container>
+    </>
+  );
+};
+
+export default LoadingPage;

--- a/src/components/LoadingPage/__snapshots__/LoadingPage.test.tsx.snap
+++ b/src/components/LoadingPage/__snapshots__/LoadingPage.test.tsx.snap
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingPage should match snapshot 1`] = `
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
+  font-size: 14px;
+  border: 1px solid #303338;
+  background-color: #295FF4;
+  color: #fff;
+  border-radius: 32px;
+  padding: 0.5rem 0.8rem;
+  margin: 0.2rem;
+  width: auto;
+}
+
+.c8:disabled {
+  color: initial;
+  opacity: 0.4;
+  cursor: auto;
+}
+
+.c8:hover:enabled {
+  border-color: #fff;
+}
+
+.c8:active:enabled {
+  border: 1px solid #303338;
+}
+
+.c4 {
+  font-family: 'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI','Roboto','Oxygen','Ubuntu','Cantarell','Fira Sans','Droid Sans','Helvetica Neue',sans-serif;
+  font-size: 20px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.c1 {
+  box-sizing: 'border-box';
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.c2 {
+  width: 1200px;
+  max-width: calc(100% - 1.25rem);
+  margin: 0 auto;
+}
+
+.c10 {
+  -webkit-animation: fvtopB 1s cubic-bezier(0.42,0.8,0.6,0.83) infinite;
+  animation: fvtopB 1s cubic-bezier(0.42,0.8,0.6,0.83) infinite;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin: 0 auto;
+}
+
+.c0 {
+  padding: 0.75rem 0;
+  max-height: 80px;
+  position: -webkit-sticky;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background: #1B1D1F;
+  z-index: 200;
+  border-bottom: 1px solid #303338;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0;
+  color: #fff;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-left: auto;
+}
+
+.c5 {
+  cursor: pointer;
+}
+
+.c6 {
+  width: 40%;
+  max-height: 50px;
+}
+
+.c9 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin: 0 auto;
+}
+
+.c11 {
+  font-size: 1rem;
+}
+
+@media only screen and (min-width:768px) {
+  .c2 {
+    padding: 3rem 0rem;
+  }
+}
+
+@media only screen and(min-width:768px) {
+  .c0 {
+    padding: 1.5rem 0;
+  }
+}
+
+<div>
+   
+  <header
+    class="c0"
+  >
+    <div
+      class="c1 c2 c3"
+    >
+      <h2
+        class="c4 c5"
+        data-testid="project-name"
+        size="2"
+      >
+        <svg
+          class="c6"
+        >
+          project_davi_logo_white.svg
+        </svg>
+      </h2>
+      <div
+        class="c1 c7"
+      >
+        <button
+          class="c8"
+        >
+          notConnected
+        </button>
+        <button
+          class="c8"
+          data-testid="connect-wallet-btn"
+        >
+          connectWallet
+        </button>
+      </div>
+    </div>
+  </header>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c9"
+    >
+      <div
+        class=""
+      >
+        <div
+          class="c10"
+        >
+          <svg
+            fill="currentColor"
+            height="80"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 1024 1024"
+            width="80"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 0 0-94.3-139.9 437.71 437.71 0 0 0-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+            />
+          </svg>
+        </div>
+      </div>
+      <p
+        class="c11"
+      >
+        loadingDao
+      </p>
+    </div>
+  </div>
+   
+</div>
+`;

--- a/src/components/LoadingPage/index.ts
+++ b/src/components/LoadingPage/index.ts
@@ -1,0 +1,1 @@
+export { default as LoadingPage } from './LoadingPage';

--- a/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.test.tsx
+++ b/src/components/ProposalCard/ProposalCardWinningOption/ProposalCardWinningOption.test.tsx
@@ -47,6 +47,12 @@ jest.mock('wagmi', () => ({
   useNetwork: () => ({ chain: mockChain, chains: [mockChain] }),
 }));
 
+jest.mock('provider/ReadOnlyConnector', () => ({
+  READ_ONLY_CONNECTOR_ID: 'readOnly',
+}));
+
+jest.mock('contexts/Guilds/orbis', () => ({}));
+
 describe('ProposalCardWinningOption', () => {
   it('renders properly with one action', () => {
     const { container } = render(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -317,5 +317,6 @@
   "postOptions": {
     "edit": "Edit",
     "delete": "Delete"
-  }
+  },
+  "loadingDao": "Loading DAO"
 }

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -4,6 +4,7 @@ import { SHA256, enc } from 'crypto-js';
 import { useMatch } from 'react-router-dom';
 import { GovernanceTypeInterface, HookStoreContextInterface } from './types';
 import { governanceInterfaces } from './governanceInterfaces';
+import { LoadingPage } from 'components/LoadingPage';
 
 export const HookStoreContext = createContext<HookStoreContextInterface>(null);
 
@@ -121,10 +122,8 @@ export const HookStoreProvider = ({ children }) => {
     return () => clearInterval(interval);
   }, [governanceType, useDefaultDataSource]);
 
-  // TODO: Make a better loading screen
-
   return isLoading ? (
-    <>Loading...</>
+    <LoadingPage />
   ) : (
     <HookStoreContext.Provider value={{ ...governanceType, isLoading, daoId }}>
       {children}


### PR DESCRIPTION
# Description

Added a loading screen when loading the governance type (while switching between DAOs).

This doesn't affect any functionality, just replaces the previous blank screen and "loading" text with a spinner and the DAVI styles.

![image](https://user-images.githubusercontent.com/75996796/210860893-54a60dde-969b-45c6-ba0d-689fe6517a21.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added snapshot test.

To test it:
 - Change guilds, either via the landing page or going to the URL. The loading spinner should briefly appear.
 - To see it fully, add a `true` condition to the return of the main store in `stores > index`, like: `return true ? (` in line 125.

# Checklist:

- [x] My code follows the existing style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any UI changes have been tested and made responsive for mobile views
